### PR TITLE
Fix TemplateSyntaxError in page.html jinja template

### DIFF
--- a/templates/page.html
+++ b/templates/page.html
@@ -4,7 +4,7 @@
 
 {% block header %}
     <!-- Page Header -->
-    <header class="intro-header" style="background-image: url('{{ page.header_cover|default({{ SITEURL }}/{{ THEME_STATIC_DIR }}/images/home-bg.jpg') }})">
+    <header class="intro-header" style="background-image: url('{{ page.header_cover|default('{{ SITEURL }}/{{ THEME_STATIC_DIR }}/images/home-bg.jpg') }}')">
     {% if page.header_cover %}
         <header class="intro-header" style="background-image: url('{{ page.header_cover }}')">
     {% else %}


### PR DESCRIPTION
```
File "/srv/pelican/themes/pelican-clean-blog/templates/page.html", line 7, in templat
<header class="intro-header" style="background-image: url('{{ page.header_cover|default({{ SITEURL }}/{{ THEME_STATIC_DIR }}/images/home-bg.jpg') }})">
jinja2.exceptions.TemplateSyntaxError: expected token ':', got '}'
```
