### PR TITLE
only show <hr> if pagination is enabled

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -41,10 +41,8 @@
                  {% include 'comments.html' %}
             </p>
         </div>
-        <hr>
     {% endfor %}
 
     {% include "pagination.html" %}
-    <hr>
 {% endblock content %}
 

--- a/templates/pagination.html
+++ b/templates/pagination.html
@@ -1,4 +1,5 @@
 {% if DEFAULT_PAGINATION %}
+    <hr>
     <!-- Pager -->
     <ul class="pager">
         <li class="next">
@@ -11,4 +12,5 @@
         </li>
     </ul>
     Page {{ articles_page.number }} / {{ articles_paginator.num_pages }}
+    <hr>
 {% endif %}


### PR DESCRIPTION
When pagination was diasabled, the surrounding horizontal rows where still shown. This commit fixes this misbehaviour.