### PR TITLE
change default behaviour for article's bg images

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Github, Twitter and Linkedin URLs set these properties:
 GITHUB_URL = 'http://github.com/myprofile'
 TWITTER_URL = 'http://twitter.com/myprofile'
 LINKEDIN_URL = 'https://de.linkedin.com/in/myprofile'
+MAIL_ADDRESS = 'name@example.com'
 ```
 
 If you have insert new links, customize ``base.html``.

--- a/README.md
+++ b/README.md
@@ -20,12 +20,12 @@ HEADER_COVER = 'static/my_image.png'
 
 ### Social URLs
 
-Github, Twitter and Facebook URLs set these properties:
+Github, Twitter and Linkedin URLs set these properties:
 
 ```python
 GITHUB_URL = 'http://github.com/myprofile'
 TWITTER_URL = 'http://twitter.com/myprofile'
-FACEBOOK_URL = 'http://facebook.com/myprofile'
+LINKEDIN_URL = 'https://de.linkedin.com/in/myprofile'
 ```
 
 If you have insert new links, customize ``base.html``.

--- a/templates/article.html
+++ b/templates/article.html
@@ -32,6 +32,8 @@
     <!-- Page Header -->
     {% if article.header_cover %}
         <header class="intro-header" style="background-image: url('{{ article.header_cover }}')">
+    {% elif HEADER_COVER %}
+        <header class="intro-header" style="background-image: url('{{ HEADER_COVER }}')">
     {% else %}
         <header class="intro-header" style="background-image: url('{{ SITEURL }}/{{ THEME_STATIC_DIR }}/images/post-bg.jpg')">
     {% endif %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -143,12 +143,12 @@
                             </a>
                         </li>
                     {% endif %}
-                    {% if FACEBOOK_URL %}
+                    {% if LINKEDIN_URL %}
                         <li>
-                            <a href="{{ FACEBOOK_URL }}">
+                            <a href="{{ LINKEDIN_URL }}">
                                 <span class="fa-stack fa-lg">
                                     <i class="fa fa-circle fa-stack-2x"></i>
-                                    <i class="fa fa-facebook fa-stack-1x fa-inverse"></i>
+                                    <i class="fa fa-linkedin fa-stack-1x fa-inverse"></i>
                                 </span>
                             </a>
                         </li>

--- a/templates/base.html
+++ b/templates/base.html
@@ -153,6 +153,16 @@
                             </a>
                         </li>
                     {% endif %}
+                    {% if MAIL_ADDRESS %}
+                        <li>
+                            <a href="mailto:{{ MAIL_ADDRESS }}">
+                                <span class="fa-stack fa-lg">
+                                    <i class="fa fa-circle fa-stack-2x"></i>
+                                    <i class="fa fa-envelope fa-stack-1x fa-inverse"></i>
+                                </span>
+                            </a>
+                        </li>
+                    {% endif %}
                     {% if GITHUB_URL %}
                         <li>
                             <a href="{{ GITHUB_URL }}">

--- a/templates/index.html
+++ b/templates/index.html
@@ -41,10 +41,8 @@
                  {% include 'comments.html' %}
             </p>
         </div>
-        <hr>
     {% endfor %}
 
     {% include "pagination.html" %}
-    <hr>
 {% endblock content %}
 

--- a/templates/pagination.html
+++ b/templates/pagination.html
@@ -1,4 +1,5 @@
 {% if DEFAULT_PAGINATION %}
+    <hr>
     <!-- Pager -->
     <ul class="pager">
         <li class="next">
@@ -11,4 +12,5 @@
         </li>
     </ul>
     Page {{ articles_page.number }} / {{ articles_paginator.num_pages }}
+    <hr>
 {% endif %}


### PR DESCRIPTION
If there is not bg image defined for an article, the template should default to the site's background image and then to the theme's default.