### PR TITLE
Get social urls from SOCIAL

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,12 +23,14 @@ HEADER_COVER = 'static/my_image.png'
 Github, Twitter and Facebook URLs set these properties:
 
 ```python
-GITHUB_URL = 'http://github.com/myprofile'
-TWITTER_URL = 'http://twitter.com/myprofile'
-FACEBOOK_URL = 'http://facebook.com/myprofile'
+SOCIAL = (('twitter', 'https://twitter.com/myprofile'),
+          ('github', 'https://github.com/myprofile'),
+          ('facebook','https://facebook.com/myprofile'),
+          ('flickr','https://www.flickr.com/myprofile/'),
+          ('envelope','mailto:my@mail.address'))
 ```
 
-If you have insert new links, customize ``base.html``.
+If you have new links add them to SOCIAL. The Name has to be the name of the corresponding FontAwesome icon.
 
 ### Code highlights
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -133,35 +133,17 @@
             <div class="row">
                 <div class="col-lg-8 col-lg-offset-2 col-md-10 col-md-offset-1">
                     <ul class="list-inline text-center">
-                    {% if TWITTER_URL %}
-                        <li>
-                            <a href="{{ TWITTER_URL }}">
-                                <span class="fa-stack fa-lg">
-                                    <i class="fa fa-circle fa-stack-2x"></i>
-                                    <i class="fa fa-twitter fa-stack-1x fa-inverse"></i>
-                                </span>
-                            </a>
-                        </li>
-                    {% endif %}
-                    {% if FACEBOOK_URL %}
-                        <li>
-                            <a href="{{ FACEBOOK_URL }}">
-                                <span class="fa-stack fa-lg">
-                                    <i class="fa fa-circle fa-stack-2x"></i>
-                                    <i class="fa fa-facebook fa-stack-1x fa-inverse"></i>
-                                </span>
-                            </a>
-                        </li>
-                    {% endif %}
-                    {% if GITHUB_URL %}
-                        <li>
-                            <a href="{{ GITHUB_URL }}">
-                                <span class="fa-stack fa-lg">
-                                    <i class="fa fa-circle fa-stack-2x"></i>
-                                    <i class="fa fa-github fa-stack-1x fa-inverse"></i>
-                                </span>
-                            </a>
-                        </li>
+                    {% if SOCIAL %}
+                        {% for name,link in SOCIAL %}
+                            <li>
+                                <a href="{{ link }}">
+                                    <span class="fa-stack fa-lg">
+                                        <i class="fa fa-circle fa-stack-2x"></i>
+                                        <i class="fa fa-{{ name|lower }} fa-stack-1x fa-inverse"></i>
+                                    </span>
+                                </a>
+                            </li>
+                        {% endfor %}
                     {% endif %}
                     </ul>
                     <p class="copyright text-muted">Blog powered by <a href="http://getpelican.com">Pelican</a>,


### PR DESCRIPTION
I removed the URL config options for every service and replaced it with a central option called SOCIAL which contains all services and can be extended easily, because the name of the service is also the name of the FA icon.