### PR TITLE
New setting: SHOW_FULL_ARTICLE

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,11 @@ Accept many analytics:
  - Gauges: ``GAUGES`` 
  - Piwik: ``PIWIK_URL`` and ``PIWIK_SITE_ID``.
 
+### Other configuration
+
+ - Set ``SHOW_FULL_ARTICLE`` to True to show full article content on index.html
+ instead of summary;
+
 ### Articles
 
 To customize header cover to articles, insert the metadata ``header_cover``:

--- a/templates/index.html
+++ b/templates/index.html
@@ -32,7 +32,9 @@
                     {{ article.title }}
                 </h2>
             </a>
-            {% if article.summary %}
+            {% if SHOW_FULL_ARTICLE %}
+                {{ article.content }}
+            {% elif article.summary %}
                 {{ article.summary|truncate(140) }}
             {% endif %}
             <p class="post-meta">Posted by


### PR DESCRIPTION
when set to True will show the full article content on index.html
instead of truncated summary.