### PR TITLE
Fix broken HTML tags

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -40,8 +40,8 @@
                     <a href="{{ SITEURL }}/{{ author.url }}">{{ author }}</a>
                 {% endfor %}
                  on {{ article.locale_date }}
-                 {% include 'comments.html' %}
             </p>
+            {% include 'comments.html' %}
         </div>
     {% endfor %}
 


### PR DESCRIPTION
The </p> tag should close before inserting the comments.