### PR TITLE
Use LOCALE instead of DEFAULT_LANG to set og:locale

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -68,7 +68,9 @@
     {% endblock head %}
 
 	{% block opengraph %}
-		<meta property="og:locale" content="{{ DEFAULT_LANG }}">
+            {% for LOC in LOCALE %}
+                <meta property="og:locale" content="{{ LOC }}">
+            {% endfor %}
 		<meta property="og:site_name" content="{{ SITENAME }}">
 	{% endblock opengraph %}
 </head>


### PR DESCRIPTION
DEFAULT_LANG value is 'en' while og:locale format is 'en_US'
which is the value of LOCALE as well. Pelican converts LOCALE to a list before rendering the templates.

