### PR TITLE
Make it possible to define custom footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,17 @@ CSS_OVERRIDE = 'myblog.css'
 Set ``DISABLE_CUSTOM_THEME_JAVASCRIPT`` to True if you want to disable
 ``js/clean-blog.min.js`` in case it affects forms and input fields.
 
+### User defined footer
+
+Define ``FOOTER_INCLUDE`` in ``pelicanconf.py`` to insert a custom footer text
+instead the default "Powered by Pelican". The value is a template path. You also
+need to define the ``EXTRA_TEMPLATES_PATHS`` setting. Example:
+
+```python
+FOOTER_INCLUDE = 'myfooter.html'
+EXTRA_TEMPLATES_PATHS = [os.path.dirname(__file__)]
+```
+
 ### Analytics
 
 Accept many analytics:

--- a/templates/base.html
+++ b/templates/base.html
@@ -146,8 +146,11 @@
                         {% endfor %}
                     {% endif %}
                     </ul>
-                    <p class="copyright text-muted">Blog powered by <a href="http://getpelican.com">Pelican</a>,
-                which takes great advantage of <a href="http://python.org">Python</a>.</p>
+                    {% if FOOTER_INCLUDE %}
+                        {% include FOOTER_INCLUDE %}
+                    {% else %}
+                        {% include 'footer.html' %}
+                    {% endif %}
                 </div>
             </div>
         </div>

--- a/templates/footer.html
+++ b/templates/footer.html
@@ -1,0 +1,4 @@
+<p class="copyright text-muted">
+    Blog powered by <a href="http://getpelican.com">Pelican</a>,
+    which takes great advantage of <a href="http://python.org">Python</a>.
+</p>


### PR DESCRIPTION
Using the FOOTER_INCLUDE and EXTRA_TEMPLATES_PATHS settings it
is now possible to include a custom footer template instead of
the default "Powered by Pelican"!