### PR TITLE
Update meta tags and add support for og:image

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,11 @@ Accept many analytics:
 
 ### Articles
 
-To customize header cover to articles, insert the metadata ``header_cover``:
+To customize header cover to articles, insert the metadata ``header_cover``.
+To customize OpenGraph images, insert the metadata ``og_image``, otherwise
+``header_cover``, ``HEADER_COVER`` or a default image is used. You can also
+use absolute URLs for ``og_image``. Example:
+
 
  - To RST
 ```rst
@@ -113,6 +117,7 @@ My super title
 :authors: Alexis Metaireau, Conan Doyle
 :summary: Short version for index and feeds
 :header_cover: /images/posts/super-title/cover.png
+:og_image: /images/posts/super-title/facebook_cover.png
 ```
 
  - To Markdown
@@ -126,6 +131,7 @@ Slug: my-super-post
 Authors: Alexis Metaireau, Conan Doyle
 Summary: Short version for index and feeds
 Header_Cover: /images/posts/super-title/cover.png
+Og_Image: http://example.com/facebook_cover.png
 
 This is the content of my super blog post.
 ```

--- a/templates/article.html
+++ b/templates/article.html
@@ -5,28 +5,56 @@
     {{ super() }}
 
     {% for keyword in article.keywords %}
-        <meta name="keywords" contents="{{keyword}}" />
+        <meta name="keywords" content="{{keyword}}" >
     {% endfor %}
 
-    {% for description in article.description %}
-        <meta name="description" contents="{{description}}" />
+    {% if description %}
+        <meta name="description" content="{{ description }}">
+    {% elif article.headline %}
+        <meta name="description" content="{{ article.headline }}">
+    {% elif article.summary %}
+        <meta name="description" content="{{ article.summary|striptags|truncate(140) }}">
+    {% endif %}
+
+    {% for author in article.authors %}
+        <meta name="author" content="{{ author }}">
     {% endfor %}
 
     {% for tag in article.tags %}
-        <meta name="tags" contents="{{tag}}" />
+        <meta name="tags" content="{{tag}}">
     {% endfor %}
-
 {% endblock %}
 
 {% block opengraph %}
 	{{ super() }}
 	<meta property="og:type" content="article">
-	<meta property="article:author" content="{{ author }}">
+        {% for author in article.authors %}
+            <meta property="article:author" content="{{ author }}" >
+        {% endfor %}
 	<meta property="og:url" content="{{ SITEURL }}/{{ article.url }}">
 	<meta property="og:title" content="{{ article.title }}">
-	<meta property="og:description" content="{{ article.headline }}">
-	<meta property="og:image" content="{{ SITEURL }}/{{ article.header_cover }}">
 	<meta property="article:published_time" content="{{ article.date }}">
+        {% if description %}
+            <meta property="og:description" content="{{ description }}">
+        {% elif article.headline %}
+            <meta property="og:description" content="{{ article.headline }}">
+        {% elif article.summary %}
+            <meta property="og:description" content="{{ article.summary|striptags|truncate(140) }}">
+        {% endif %}
+
+        {% if article.og_image %}
+            {% if article.og_image|lower|truncate(4, True, '') == "http" %}
+                <meta property="og:image" content="{{ article.og_image }}">
+            {% else %}
+                <meta property="og:image" content="{{ SITEURL }}/{{ article.og_image }}">
+            {% endif %}
+        {% elif article.header_cover %}
+            <meta property="og:image" content="{{ SITEURL }}/{{ article.header_cover }}">
+        {% elif HEADER_COVER %}
+            <meta property="og:image" content="{{ SITEURL }}/{{ HEADER_COVER }}">
+        {% else %}
+            <meta property="og:image" content="{{ SITEURL }}/{{ THEME_STATIC_DIR }}/images/post-bg.jpg">
+        {% endif %}
 {% endblock %}
 
 {% block header %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -6,8 +6,6 @@
         <meta charset="utf-8">
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        <meta name="description" content="">
-        <meta name="author" content="">
 
         {% if GOOGLE_SITE_VERIFICATION %}
             <meta name="google-site-verification" content="{{ GOOGLE_SITE_VERIFICATION }}">


### PR DESCRIPTION
I've fixed several typos and unified the use (or not suing actually) of a closing slash for all meta tags. 

I've added support for og:image used by Facebook. You can specify a custom image per article, because Facebook can be picky about image dimensions. If this is missing the defaults for header cover are used (same as everywhere else). 

I have updated the description tags based on hints from #26 . 

Note: the article:author tags contain the name of the person but this is not valid OpenGraph syntax. See: https://github.com/niallkennedy/open-graph-protocol-examples/blob/master/article-utc.html

This needs to be updated in a later commit.