### PR TITLE
Start using SUMMARY_MAX_LENGTH

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -31,7 +31,7 @@
                 </h2>
             </a>
             {% if article.summary %}
-                {{ article.summary|truncate(140) }}
+                {{ article.summary }}
             {% endif %}
             <p class="post-meta">Posted by
                 {% for author in article.authors %}


### PR DESCRIPTION
Modified index.html template to start using SUMMARY_MAX_LENGTH instead
of forcing a 140 character truncation