### PR TITLE
Add `striptags` to summary before truncate

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -39,7 +39,7 @@
             {% elif article.has_summary %}
                 {{ article.summary }}
             {% elif article.summary %}
-                {{ article.summary|truncate(140) }}
+                {{ article.summary|striptags|truncate(140) }}
             {% endif %}
             <p class="post-meta">Posted by
                 {% for author in article.authors %}


### PR DESCRIPTION
Summary might be truncated inside an HTML tag. Summaries no longer have HTML tags, but this prevents unclosed tags in the summary which can interfere with the rest of the layout