### PR TITLE
fix pagination arrow

### DIFF
--- a/templates/pagination.html
+++ b/templates/pagination.html
@@ -3,11 +3,11 @@
     <!-- Pager -->
     <ul class="pager">
         <li class="next">
-            {% if articles_page.has_previous() %}
-                <a href="{{ SITEURL }}/{{ articles_previous_page.url }}">Newest Posts &rarr;</a>
-            {% endif %}
             {% if articles_page.has_next() %}
                 <a href="{{ SITEURL }}/{{ articles_next_page.url }}">Older Posts &rarr;</a>
+            {% endif %}
+            {% if articles_page.has_previous() %}
+                <a href="{{ SITEURL }}/{{ articles_previous_page.url }}"> &larr; Newest Posts</a>
             {% endif %}
         </li>
     </ul>


### PR DESCRIPTION
I think the pagination should be like this: 

![RIGHT PAGINATION](http://cl.ly/2U0A05431S1W/Screen%20Shot%202016-03-31%20at%2017.41.16.png)

Not like this: 

![WRONG PAGINATION](http://cl.ly/0m2A0G1C1j2i/Screen%20Shot%202016-03-31%20at%2017.38.46.png)