### PR TITLE
Make article:author OpenGraph compatible

### DIFF
--- a/templates/article.html
+++ b/templates/article.html
@@ -59,7 +59,7 @@
 	{{ super() }}
 	<meta property="og:type" content="article">
         {% for author in article.authors %}
-            <meta property="article:author" content="{{ author }}" >
+            <meta property="article:author" content="{{ SITEURL }}/{{ author.url }}">
         {% endfor %}
 	<meta property="og:url" content="{{ SITEURL }}/{{ article.url }}">
 	<meta property="og:title" content="{{ article.title }}">

--- a/templates/author.html
+++ b/templates/author.html
@@ -2,6 +2,15 @@
 
 {% block title %}{{ SITENAME }} - Articles by {{ author }}{% endblock %}
 
+{% block opengraph %}
+    {{ super() }}
+    <meta property="og:title" content="{{ SITENAME }} - Articles by {{ author }}">
+    <meta property="og:type" content="profile">
+    <meta property="profile:first_name" content="{{ author.name.split(' ')[0] }}">
+    <meta property="profile:last_name" content="{{ author.name.split(' ')[1:]|join(' ') }}">
+    <meta property="profile:username" content="{{ author.slug }}">
+{% endblock opengraph %}
+
 {% block header %}
     <!-- Page Header -->
     {% if HEADER_COVER %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -6,8 +6,6 @@
         <meta charset="utf-8">
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        <meta name="description" content="">
-        <meta name="author" content="{{ AUTHOR }}">
 
         {% if GOOGLE_SITE_VERIFICATION %}
             <meta name="google-site-verification" content="{{ GOOGLE_SITE_VERIFICATION }}">


### PR DESCRIPTION
OpenGraph actually needs a profile URL as value to article:author.
We point it to the author's page and adjust the OG meta tags on
author.html to include the relevant profile information.