### PR TITLE
article: Remove trailing comma from tag list

### DIFF
--- a/templates/article.html
+++ b/templates/article.html
@@ -131,7 +131,7 @@
 
     {% if article.tags %}
         <div class="tags">
-            <p>tags: {% for tag in article.tags %}<a href="{{ SITEURL }}/{{ tag.url }}">{{ tag | escape }}</a>, {% endfor %}</p>
+            <p>tags: {% for tag in article.tags %}<a href="{{ SITEURL }}/{{ tag.url }}">{{ tag | escape }}</a>{% if not loop.last %}, {% endif %}{% endfor %}</p>
         </div>
     {% endif %}
 


### PR DESCRIPTION
Remove trailing ', ' from the tag list in the article template.