### PR TITLE
base.html: Use minified jQuery

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -180,7 +180,7 @@
     </footer>
 
     <!-- jQuery -->
-    <script src="{{ SITEURL }}/{{ THEME_STATIC_DIR }}/js/jquery.js"></script>
+    <script src="{{ SITEURL }}/{{ THEME_STATIC_DIR }}/js/jquery.min.js"></script>
 
     <!-- Bootstrap Core JavaScript -->
     <script src="{{ SITEURL }}/{{ THEME_STATIC_DIR }}/js/bootstrap.min.js"></script>


### PR DESCRIPTION
The minified version is used for all other libraries. I can't find any reason not to use it for jQuery as well.