### PR TITLE
add link to post in the post-heading

### DIFF
--- a/templates/article.html
+++ b/templates/article.html
@@ -110,6 +110,7 @@
                                 <a href="{{ SITEURL }}/{{ author.url }}">{{ author }}</a>
                             {% endfor %}
                              on {{ article.locale_date }}
+                            <a href="{{ article.url }}"><i class="glyphicon glyphicon-link"></i></a>
                         </span>
                         {% if article.modified %}
                             <span class="meta">Updated on {{ article.locale_modified }}</span>


### PR DESCRIPTION
add a link icon in the post-heading (after the date) that links to the post url, so the user can copy the link easily