### PR TITLE
Article.html has some problem in the script about link to DISQUS 

### DIFF
--- a/templates/article.html
+++ b/templates/article.html
@@ -144,8 +144,8 @@
             <div id="disqus_thread"></div>
             <script type="text/javascript">
                 var disqus_shortname = '{{ DISQUS_SITENAME }}';
-                var disqus_identifier = '{{ article.url }}';
-                var disqus_url = '{{ SITEURL }}/{{ article.url }}';
+                //var disqus_identifier = '{{ article.url }}';
+                //var disqus_url = '{{ SITEURL }}/{{ article.url }}';
                 (function() {
                     var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
                     dsq.src = '//{{ DISQUS_SITENAME }}.disqus.com/embed.js';


### PR DESCRIPTION
Hello @gilsondev, Nice to meet you. Thank you for your beautiful templates for Pelican, really love it. 

But I find out it can't work to link the DISQUS service if setting the right DISQUS_SITENAME in `pelicanconf.py` and right setting in the web `disqus.com`.

I think the problem maybe in the `Article.html`, if mark both `var disqus_identifier = '{{ article.url }}';` and `var disqus_url = '{{ SITEURL }}/{{ article.url }}';` it can work good. so I just feedback to you and hope if I mistake something on here also can get a lesson from you. thanks too much.

```
    {% if DISQUS_SITENAME and SITEURL and article.status != "draft" %}
        <div class="comments">
            <h2>Comments !</h2>
            <div id="disqus_thread"></div>
            <script type="text/javascript">
                var disqus_shortname = '{{ DISQUS_SITENAME }}';
                //var disqus_identifier = '{{ article.url }}';
                //var disqus_url = '{{ SITEURL }}/{{ article.url }}';
                (function() {
                    var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
                    dsq.src = '//{{ DISQUS_SITENAME }}.disqus.com/embed.js';
                    (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
                })();
            </script>
            <noscript>Please enable JavaScript to view the comments.</noscript>
        </div>
    {% endif %}
```
