### PR TITLE
PAGES context variable is replaced by pages in Pelican 3.7

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -120,7 +120,8 @@
                     {% endfor %}
 
                     {% if DISPLAY_PAGES_ON_MENU %}
-                        {% for p in PAGES %}
+                        {# FIXME: Simplify to 'for p in pages' when we are ready to drop support for Pelican < 3.7 #}
+                        {% for p in PAGES or pages %}
                             <li{% if p == page %} class="active"{% endif %}><a href="{{ SITEURL }}/{{ p.url }}">{{ p.title }}</a></li>
                         {% endfor %}
                     {% else %}


### PR DESCRIPTION
By using 'or' in the if statement, we can support Pelican 3.7 and
earlier versions in the same theme. When we are ready to drop support
for Pelican <3.7, the if statement can be simplified.

See the following links for more information.

http://docs.getpelican.com/en/3.7.0/changelog.html#id1

http://docs.getpelican.com/en/3.7.0/faq.html#since-i-upgraded-pelican-my-pages-are-no-longer-rendered