### PR TITLE
Pass named arg to TAG_FEED_RSS|format

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Theme based in [Clean Blog layout](http://ironsummitmedia.github.io/startbootstrap-clean-blog/).
 
+>:warning: This theme requires Pelican 4.0 or newer.
+
 ## Screenshot
 
 ![Screenshot](screenshot.png)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Theme based in [Clean Blog layout](http://ironsummitmedia.github.io/startbootstrap-clean-blog/).
 
->:warning: This theme requires Pelican 4.0 or newer.
+>:warning: This theme requires Pelican 4.0.0 or newer.
 
 ## Screenshot
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -29,16 +29,16 @@
             <link href="{{ FEED_DOMAIN }}/{{ FEED_RSS }}" type="application/rss+xml" rel="alternate" title="{{ SITENAME }} RSS Feed" />
         {% endif %}
         {% if CATEGORY_FEED_ATOM and category %}
-            <link href="{{ FEED_DOMAIN }}/{{ CATEGORY_FEED_ATOM|format(category.slug) }}" type="application/atom+xml" rel="alternate" title="{{ SITENAME }} Categories Atom Feed" />
+            <link href="{{ FEED_DOMAIN }}/{{ CATEGORY_FEED_ATOM|format(slug=category.slug) }}" type="application/atom+xml" rel="alternate" title="{{ SITENAME }} Categories Atom Feed" />
         {% endif %}
         {% if CATEGORY_FEED_RSS and category %}
-            <link href="{{ FEED_DOMAIN }}/{{ CATEGORY_FEED_RSS|format(category.slug) }}" type="application/rss+xml" rel="alternate" title="{{ SITENAME }} Categories RSS Feed" />
+            <link href="{{ FEED_DOMAIN }}/{{ CATEGORY_FEED_RSS|format(slug=category.slug) }}" type="application/rss+xml" rel="alternate" title="{{ SITENAME }} Categories RSS Feed" />
         {% endif %}
         {% if TAG_FEED_ATOM and tag %}
-            <link href="{{ FEED_DOMAIN }}/{{ TAG_FEED_ATOM|format(tag.slug) }}" type="application/atom+xml" rel="alternate" title="{{ SITENAME }} Tags Atom Feed" />
+            <link href="{{ FEED_DOMAIN }}/{{ TAG_FEED_ATOM|format(slug=tag.slug) }}" type="application/atom+xml" rel="alternate" title="{{ SITENAME }} Tags Atom Feed" />
         {% endif %}
         {% if TAG_FEED_RSS and tag %}
-            <link href="{{ FEED_DOMAIN }}/{{ TAG_FEED_RSS|format(tag.slug) }}" type="application/rss+xml" rel="alternate" title="{{ SITENAME }} Tags RSS Feed" />
+            <link href="{{ FEED_DOMAIN }}/{{ TAG_FEED_RSS|format(slug=tag.slug) }}" type="application/rss+xml" rel="alternate" title="{{ SITENAME }} Tags RSS Feed" />
         {% endif %}
     {% endfor %}
         <!-- Bootstrap Core CSS -->


### PR DESCRIPTION
In Pelican 4.0.0 they've changed default config format of `CATEGORY_FEED_ATOM` variable from using `%s` to `{slug}`. It means that older themes developed for `Pelican<4` won't work as expected.

With Pelican 4.2.0 I received following error without any explaination what is wrong:
```
CRITICAL: TypeError: not all arguments converted during string formatting
```

Links:
* changelog: https://github.com/getpelican/pelican/blob/master/docs/changelog.rst#400-2018-11-13
* commit: https://github.com/getpelican/pelican/commit/3a0add4b6e66fe08e9f5710f98235491c09e4f81
* useful issue: https://github.com/getpelican/pelican/issues/2489